### PR TITLE
Potential fix for code scanning alert no. 1: Flask app is run in debug mode

### DIFF
--- a/auth-ext/app.py
+++ b/auth-ext/app.py
@@ -82,8 +82,9 @@ def authenticate(code):
     return {'token': token.decode()}
 
 if __name__ == "__main__":
+    debug_mode = os.environ.get("FLASK_DEBUG", "0") == "1"
     app.run(
         host=os.environ.get("BACKEND_HOST", "127.0.0.1"),
         port=5000,
-        debug=True
+        debug=debug_mode
     )


### PR DESCRIPTION
Potential fix for [https://github.com/quad6/ghas-demo/security/code-scanning/1](https://github.com/quad6/ghas-demo/security/code-scanning/1)

To fix the problem, we need to ensure that the Flask application does not run in debug mode in a production environment. The best way to achieve this is to use an environment variable to control the debug mode. This way, we can easily switch between development and production configurations without changing the code.

We will modify the `app.run` call to set the `debug` parameter based on an environment variable. Specifically, we will use the `FLASK_DEBUG` environment variable to control the debug mode. If `FLASK_DEBUG` is set to '1', debug mode will be enabled; otherwise, it will be disabled.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
